### PR TITLE
Convert quickly to SI or IP unit systems

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include requirements.txt
 include requirements-dev.txt
+include energy_pandas/energyplus_en.txt

--- a/energy_pandas/energypandas.py
+++ b/energy_pandas/energypandas.py
@@ -299,7 +299,7 @@ class EnergySeries(Series):
 
         Args:
             to_units (str, pint.Unit):
-            inplace:
+            inplace (bool): If True, conversion is applied inplace.
         """
         cdata = unit_registry.Quantity(self.values, self.units).to(to_units)
         if inplace:
@@ -641,22 +641,30 @@ class EnergySeries(Series):
         else:
             return self.data.shape[1]
 
-    def to_si(self):
-        """Convert self to SI units."""
+    def to_si(self, inplace=False):
+        """Convert self to SI units.
+
+        Args:
+            inplace (bool): If True, conversion is applied inplace.
+        """
         try:
             si_units = SI_DEFAULT_CONVERSION[self.units]
         except KeyError:
             return self
-        self.to_units(si_units, inplace=True)
+        self.to_units(si_units, inplace=inplace)
         return self
 
-    def to_ip(self):
-        """Convert self to IP units (inch-pound)."""
+    def to_ip(self, inplace=False):
+        """Convert self to IP units (inch-pound).
+
+        Args:
+            inplace (bool): If True, conversion is applied inplace.
+        """
         try:
             ip_units = IP_DEFAULT_CONVERSION[self.units]
         except KeyError:
             return self
-        self.to_units(ip_units, inplace=True)
+        self.to_units(ip_units, inplace=inplace)
         return self
 
     def plot2d(

--- a/energy_pandas/energypandas.py
+++ b/energy_pandas/energypandas.py
@@ -32,7 +32,7 @@ from .plotting import (
     _setup_subplots,
     save_and_show,
 )
-from .units import unit_registry
+from .units import unit_registry, IP_DEFAULT_CONVERSION, SI_DEFAULT_CONVERSION
 
 log = logging.getLogger(__name__)
 
@@ -643,19 +643,21 @@ class EnergySeries(Series):
 
     def to_si(self):
         """Convert self to SI units."""
-        _, si_units = unit_registry._get_base_units(self.units, system="SI")
+        try:
+            si_units = SI_DEFAULT_CONVERSION[self.units]
+        except KeyError:
+            return self
         self.to_units(si_units, inplace=True)
         return self
 
     def to_ip(self):
-        """Convert self to US units (inch-pound)."""
-        _, ip_units = unit_registry._get_base_units(self.units, system="US")
+        """Convert self to IP units (inch-pound)."""
+        try:
+            ip_units = IP_DEFAULT_CONVERSION[self.units]
+        except KeyError:
+            return self
         self.to_units(ip_units, inplace=True)
         return self
-
-    def to_compact(self):
-        """Make unit more human_readable"""
-        self.to_compact()
 
     def plot2d(
         self,

--- a/energy_pandas/energypandas.py
+++ b/energy_pandas/energypandas.py
@@ -201,7 +201,7 @@ class EnergySeries(Series):
         return es
 
     @property
-    def units(self) -> dict or Unit:
+    def units(self) -> Quantity:
         return self._units
 
     @units.setter
@@ -301,13 +301,13 @@ class EnergySeries(Series):
             to_units (str, pint.Unit):
             inplace:
         """
-        cdata = unit_registry.Quantity(self.values, self.units).to(to_units).m
+        cdata = unit_registry.Quantity(self.values, self.units).to(to_units)
         if inplace:
-            self[:] = cdata
-            self.units = to_units
+            self[:] = cdata.m
+            self.units = cdata.units
         else:
             # create new instance using constructor
-            result = self._constructor(data=cdata, index=self.index, copy=False)
+            result = self._constructor(data=cdata.m, index=self.index, copy=False)
             # Copy metadata over
             result.__finalize__(self)
             result.units = to_units
@@ -640,6 +640,22 @@ class EnergySeries(Series):
             return 1
         else:
             return self.data.shape[1]
+
+    def to_si(self):
+        """Convert self to SI units."""
+        _, si_units = unit_registry._get_base_units(self.units, system="SI")
+        self.to_units(si_units, inplace=True)
+        return self
+
+    def to_ip(self):
+        """Convert self to US units (inch-pound)."""
+        _, ip_units = unit_registry._get_base_units(self.units, system="US")
+        self.to_units(ip_units, inplace=True)
+        return self
+
+    def to_compact(self):
+        """Make unit more human_readable"""
+        self.to_compact()
 
     def plot2d(
         self,

--- a/energy_pandas/energypandas.py
+++ b/energy_pandas/energypandas.py
@@ -618,6 +618,7 @@ class EnergySeries(Series):
 
     @property
     def time_at_min(self):
+        """Return the index value where the min occurs."""
         return self.idxmin()
 
     @property
@@ -775,7 +776,7 @@ class EnergyDataFrame(DataFrame):
 
     Data structure also contains labeled axes (rows and columns). Arithmetic
     operations align on both row and column labels. Can be thought of as a
-    dict-like container for Series objects. The primary energypandas data structure.
+    dict-like container for Series objects. The primary energy-pandas data structure.
 
     """
 

--- a/energy_pandas/energyplus_en.txt
+++ b/energy_pandas/energyplus_en.txt
@@ -1,0 +1,47 @@
+# Default EnergyPlus units definition file
+# Based on input-output-reference/idd-conventions
+# Language: english
+# :copyright: 2020 by Samuel Letellier-Duchesne
+
+h = 1 * hour
+m3 = 1 * meter ** 3 = m³
+ft3 = 1 * feet ** 3 = ft³
+ft2 = 1 * feet ** 2 = ft²
+m2 = 1 * meter ** 2 = m²
+inch2 = 1 * inch ** 2 = inch²
+
+# Aliases
+@alias inch = in
+@alias lb = lbm
+@alias delta_degree_Fahrenheit = deltaF
+@alias delta_degreeC = deltaC = C
+@alias degree_Fahrenheit = F
+@alias degree_Rankine = R
+@alias degree_Kelvin = K
+@alias ton_of_refrigeration = ton
+@alias hour = h
+
+# In EnergyPlus, exponents appear without any indication of exponentiation: i.e., kg/m3 not kg/m^3 or kg/m**3
+m3 = 1 * meter ** 3 = m³
+ft3 = 1 * feet ** 3 = ft³
+ft2 = 1 * feet ** 2 = ft²
+m2 = 1 * meter ** 2 = m²
+inch2 = 1 * inch ** 2 = inch²
+K2 = 1 * degree_Kelvin ** 2 = K²
+K3 = 1 * degree_Kelvin ** 3 = K³
+F2 = 1 * degree_Fahrenheit ** 2 = F²
+F3 = 1 * degree_Fahrenheit ** 3 = F³
+s2 = 1 * second ** 2 = s²
+
+# person
+person = _
+
+#percent
+percent = 0.01 * count = %
+
+# Other units
+ach = dimensionless  # Air Changes per Hour
+acr = 1 / hour  # Air change rate
+kBtuh = 1000 * Btu * hour
+footcandle = 1 * lumen / ft2 = fc = ft-c
+ton-hrs = 1 * ton_of_refrigeration * hour

--- a/energy_pandas/energyplus_en.txt
+++ b/energy_pandas/energyplus_en.txt
@@ -14,7 +14,7 @@ inch2 = 1 * inch ** 2 = inch²
 @alias inch = in
 @alias lb = lbm
 @alias delta_degree_Fahrenheit = deltaF
-@alias delta_degreeC = deltaC = C
+@alias delta_degreeC = deltaC
 @alias degree_Fahrenheit = F
 @alias degree_Rankine = R
 @alias degree_Kelvin = K
@@ -45,3 +45,6 @@ acr = 1 / hour  # Air change rate
 kBtuh = 1000 * Btu * hour
 footcandle = 1 * lumen / ft2 = fc = ft-c
 ton-hrs = 1 * ton_of_refrigeration * hour
+
+# override
+degree_Celsius = kelvin; offset: 273.15 = °C = celsius = degC = degreeC = C  # necessary to override Coulomb C

--- a/energy_pandas/units.py
+++ b/energy_pandas/units.py
@@ -1,16 +1,148 @@
 """units module."""
 
 # Units
-import pint
+from tokenize import TokenInfo
 
-unit_registry = pint.UnitRegistry()
-unit_registry.define("m3 = 1 * meter ** 3 = m³")
-unit_registry.define(
-    "degree_Celsius = kelvin; offset: 273.15 = °C = C = celsius = degC = degreeC"
+import pint
+from pint.compat import tokenizer
+
+
+def underline_dash(input_string):
+    """Enclose denominator with parentheses."""
+    parts = []
+    gen = tokenizer(input_string)
+    for part in gen:
+        parts.append(part)
+        if part.string == "/":
+            # put rest of string in parentheses
+            parts.append(
+                TokenInfo(type=53, string="(", start=(1, 0), end=(1, 1), line="(")
+            )
+            parts.extend(list(gen))
+            parts.append(
+                TokenInfo(type=53, string=")", start=(1, 0), end=(1, 1), line="(")
+            )
+    return "".join((s.string for s in parts))
+
+
+def dash_to_mul(input_string):
+    """Replace '-' with '*' in input_string."""
+    return input_string.replace("-", "*")
+
+
+class Token:
+    def __init__(self, input_string):
+        self.string = input_string
+
+
+unit_registry = pint.UnitRegistry(preprocessors=[underline_dash, dash_to_mul])
+unit_registry.load_definitions(
+    "energy_pandas/energyplus_en.txt",
 )
-unit_registry.define(
-    "degree_Fahrenheit = 5 / 9 * kelvin; offset: 233.15 + 200 / 9 = "
-    "°F = F = fahrenheit = degF = degreeF"
-)
-unit_registry.define("ach = dimensionless")  # Air Changes per Hour
-unit_registry.define("acr = 1 / hour")  # Air change rate
+pint.set_application_registry(unit_registry)
+
+
+IP_DEFAULT_CONVERSION = {
+    unit_registry.parse_units("m3/s"): unit_registry.parse_units("ft3/min"),
+    unit_registry.parse_units("W/K"): unit_registry.parse_units("Btu/h-F"),
+    unit_registry.parse_units("kW"): unit_registry.parse_units("kBtuh/h"),
+    unit_registry.parse_units("m2"): unit_registry.parse_units("ft2"),
+    unit_registry.parse_units("m3"): unit_registry.parse_units("ft3"),
+    unit_registry.parse_units("(kg/s)/W"): unit_registry.parse_units(
+        "(lbm/sec)/(Btu/hr)"
+    ),
+    unit_registry.parse_units("1/K"): unit_registry.parse_units("1/F"),
+    unit_registry.parse_units("1/m"): unit_registry.parse_units("1/ft"),
+    unit_registry.parse_units("A/K"): unit_registry.parse_units("A/F"),
+    unit_registry.parse_units("C"): unit_registry.parse_units("F"),
+    unit_registry.parse_units("cm"): unit_registry.parse_units("in"),
+    unit_registry.parse_units("cm2"): unit_registry.parse_units("inch2"),
+    unit_registry.parse_units("deltaC"): unit_registry.parse_units("deltaF"),
+    # unit_registry.parse_units("deltaJ/kg"): unit_registry.parse_units("deltaBtu/lb"),
+    unit_registry.parse_units("g/GJ"): unit_registry.parse_units("lb/MWh"),
+    unit_registry.parse_units("g/kg"): unit_registry.parse_units("grains/lb"),
+    unit_registry.parse_units("g/MJ"): unit_registry.parse_units("lb/MWh"),
+    unit_registry.parse_units("g/mol"): unit_registry.parse_units("lb/mol"),
+    unit_registry.parse_units("g/m-s"): unit_registry.parse_units("lb/ft-s"),
+    unit_registry.parse_units("g/m-s-K"): unit_registry.parse_units("lb/ft-s-F"),
+    unit_registry.parse_units("GJ"): unit_registry("ton-hrs"),
+    unit_registry.parse_units("J"): unit_registry.parse_units("Wh"),
+    unit_registry.parse_units("J/K"): unit_registry.parse_units("Btu/F"),
+    unit_registry.parse_units("J/kg"): unit_registry.parse_units("Btu/lb"),
+    unit_registry.parse_units("J/kg-K"): unit_registry.parse_units("Btu/lb-F"),
+    unit_registry.parse_units("J/kg-K2"): unit_registry.parse_units("Btu/lb-F2"),
+    unit_registry.parse_units("J/kg-K3"): unit_registry.parse_units("Btu/lb-F3"),
+    unit_registry.parse_units("J/m2-K"): unit_registry.parse_units("Btu/ft2-F"),
+    unit_registry.parse_units("J/m3"): unit_registry.parse_units("Btu/ft3"),
+    unit_registry.parse_units("J/m3-K"): unit_registry.parse_units("Btu/ft3-F"),
+    unit_registry.parse_units("K"): unit_registry.parse_units("R"),
+    unit_registry.parse_units("K/m"): unit_registry.parse_units("F/ft"),
+    unit_registry.parse_units("kg"): unit_registry.parse_units("lb"),
+    unit_registry.parse_units("kg/J"): unit_registry.parse_units("lb/Btu"),
+    unit_registry.parse_units("kg/kg-K"): unit_registry.parse_units("lb/lb-F"),
+    unit_registry.parse_units("kg/m"): unit_registry.parse_units("lb/ft"),
+    unit_registry.parse_units("kg/m2"): unit_registry.parse_units("lb/ft2"),
+    unit_registry.parse_units("kg/m3"): unit_registry.parse_units("lb/ft3"),
+    unit_registry.parse_units("kg/m-s"): unit_registry.parse_units("lb/ft-s"),
+    unit_registry.parse_units("kg/m-s-K"): unit_registry.parse_units("lb/ft-s-F"),
+    unit_registry.parse_units("kg/m-s-K2"): unit_registry.parse_units("lb/ft-s-F2"),
+    unit_registry.parse_units("kg/Pa-s-m2"): unit_registry.parse_units("lb/psi-s-ft2"),
+    unit_registry.parse_units("kg/s"): unit_registry.parse_units("lb/s"),
+    unit_registry.parse_units("kg/s2"): unit_registry.parse_units("lb/s2"),
+    unit_registry.parse_units("kg/s-m"): unit_registry.parse_units("lb/s-ft"),
+    unit_registry.parse_units("kJ/kg"): unit_registry.parse_units("Btu/lb"),
+    unit_registry.parse_units("kPa"): unit_registry.parse_units("psi"),
+    unit_registry.parse_units("L/day"): unit_registry.parse_units("pint/day"),
+    unit_registry.parse_units("L/GJ"): unit_registry.parse_units("gal/kWh"),
+    unit_registry.parse_units("L/kWh"): unit_registry.parse_units("pint/kWh"),
+    unit_registry.parse_units("L/MJ"): unit_registry.parse_units("gal/kWh"),
+    unit_registry.parse_units("lux"): unit_registry.parse_units("footcandles"),
+    unit_registry.parse_units("m"): unit_registry.parse_units("ft"),
+    unit_registry.parse_units("m/hr"): unit_registry.parse_units("ft/hr"),
+    unit_registry.parse_units("m/s"): unit_registry.parse_units("ft/min"),
+    unit_registry.parse_units("m/yr"): unit_registry.parse_units("inch/yr"),
+    unit_registry.parse_units("m2"): unit_registry.parse_units("ft2"),
+    unit_registry.parse_units("m2/m"): unit_registry.parse_units("ft2/ft"),
+    unit_registry.parse_units("m2/person"): unit_registry.parse_units("ft2/person"),
+    unit_registry.parse_units("m2/s"): unit_registry.parse_units("ft2/s"),
+    unit_registry.parse_units("m2-K/W"): unit_registry.parse_units("ft2-F-hr/Btu"),
+    unit_registry.parse_units("m3"): unit_registry.parse_units("ft3"),
+    unit_registry.parse_units("m3/GJ"): unit_registry.parse_units("ft3/MWh"),
+    unit_registry.parse_units("m3/hr"): unit_registry.parse_units("ft3/hr"),
+    unit_registry.parse_units("m3/hr-m2"): unit_registry.parse_units("ft3/hr-ft2"),
+    unit_registry.parse_units("m3/hr-person"): unit_registry.parse_units(
+        "ft3/hr-person"
+    ),
+    unit_registry.parse_units("m3/kg"): unit_registry.parse_units("ft3/lb"),
+    unit_registry.parse_units("m3/m2"): unit_registry.parse_units("ft3/ft2"),
+    unit_registry.parse_units("m3/MJ"): unit_registry.parse_units("ft3/kWh"),
+    unit_registry.parse_units("m3/person"): unit_registry.parse_units("ft3/person"),
+    unit_registry.parse_units("m3/s"): unit_registry.parse_units("ft3/min"),
+    unit_registry.parse_units("m3/s-m"): unit_registry.parse_units("ft3/min-ft"),
+    unit_registry.parse_units("m3/s-m2"): unit_registry.parse_units("ft3/min-ft2"),
+    unit_registry.parse_units("m3/s-person"): unit_registry.parse_units(
+        "ft3/min-person"
+    ),
+    unit_registry.parse_units("m3/s-W"): unit_registry.parse_units("(ft3/min)/(Btu/h)"),
+    unit_registry.parse_units("N-m"): unit_registry.parse_units("lbf-in"),
+    unit_registry.parse_units("N-s/m2"): unit_registry.parse_units("lbf-s/ft2"),
+    unit_registry.parse_units("Pa"): unit_registry.parse_units("psi"),
+    unit_registry.parse_units("percent/K"): unit_registry.parse_units("percent/F"),
+    unit_registry.parse_units("person/m2"): unit_registry.parse_units("person/ft2"),
+    unit_registry.parse_units("s/m"): unit_registry.parse_units("s/ft"),
+    unit_registry.parse_units("V/K"): unit_registry.parse_units("V/F"),
+    unit_registry.parse_units("W"): unit_registry.parse_units("Btu/h"),
+    unit_registry.parse_units("W/(m3/s)"): unit_registry.parse_units("W/(ft3/min)"),
+    unit_registry.parse_units("W/K"): unit_registry.parse_units("Btu/h-F"),
+    unit_registry.parse_units("W/m"): unit_registry.parse_units("Btu/h-ft"),
+    unit_registry.parse_units("W/m2"): unit_registry.parse_units("Btu/h-ft2"),
+    unit_registry.parse_units("W/m2"): unit_registry.parse_units("W/ft2"),
+    unit_registry.parse_units("W/m2-K"): unit_registry.parse_units("Btu/h-ft2-F"),
+    unit_registry.parse_units("W/m2-K2"): unit_registry.parse_units("Btu/h-ft2-F2"),
+    unit_registry.parse_units("W/m-K"): unit_registry.parse_units("Btu-in/h-ft2-F"),
+    unit_registry.parse_units("W/m-K2"): unit_registry.parse_units("Btu/h-F2-ft"),
+    unit_registry.parse_units("W/m-K3"): unit_registry.parse_units("Btu/h-F3-ft"),
+    unit_registry.parse_units("W/person"): unit_registry.parse_units("Btu/h-person"),
+}
+
+SI_DEFAULT_CONVERSION = {v: k for k, v in IP_DEFAULT_CONVERSION.items()}

--- a/tests/test_energypandas.py
+++ b/tests/test_energypandas.py
@@ -80,6 +80,16 @@ class TestEnergySeries:
         es.to_units(to_units="kelvin", inplace=True)
         assert es.equals(original + 273.15)
 
+    def test_units_SI_system(self, es):
+        """test unit conversion."""
+        es.units = "W"
+        print(es.to_si().units)
+
+    def test_units_IP_system(self, es):
+        """test unit conversion."""
+        es.units = "W"
+        print(es.to_ip().units)
+
     def test_units_ops(self, edf_from_e_series):
         a = edf_from_e_series["Series 1 degC"]
         b = edf_from_e_series["Series 2 degK"]


### PR DESCRIPTION
Convert quickly to SI or IP unit systems. Conversions are based on the default conversion as defined in EnergyPlus IDD file.

```python
>>> import energy_pandas as ep
>>> es = ep.EnergySeries(range(0, 10), units="W/m2-K") # heat transfer coefficient
>>> es.to_ip(inplace=True).units  # can be applied inplace or not
<Unit('british_thermal_unit / delta_degree_Fahrenheit / ft2 / hour')>
```