### PR TITLE
Convert all mixed-units of an EnergyDataFrame using to_units

### DIFF
--- a/energy_pandas/energypandas.py
+++ b/energy_pandas/energypandas.py
@@ -957,6 +957,19 @@ class EnergyDataFrame(DataFrame):
         Args:
             to_units (str or pint.Unit):
             inplace (bool): If True, conversion is applied inplace.
+
+        Examples:
+            >>> import energy_pandas as epd
+            >>> edf = epd .EnergyDataFrame(
+            >>>         {
+            >>>             "Series 1": epd.EnergySeries(range(0, 8760), units="degC"),
+            >>>             "Series 2": epd.EnergySeries(range(0, 8760), units="degK"),
+            >>>             "Series 3": epd.EnergySeries(range(0, 8760), units="degR"),
+            >>>         },
+            >>> )
+            >>> edf.to_units("degC").units
+            {'Series 1': <Unit('degree_Celsius')>, 'Series 2': <Unit('degree_Celsius')>, 'Series 3': <Unit('degree_Celsius')>}
+
         """
         cdata = self.apply(
             lambda col: unit_registry.Quantity(col.values, col.units).to(to_units)

--- a/tests/test_energypandas.py
+++ b/tests/test_energypandas.py
@@ -189,8 +189,12 @@ class TestEnergyDataFrame:
         assert edf_from_e_series[["Series 1 degC"]].units == {
             "Series 1 degC": unit_registry.degC
         }
-        with pytest.raises(MultipleUnitsError):
-            edf_from_e_series.to_units("degF")
+
+    def test_mixed_units_convert(self, edf_from_e_series):
+        assert edf_from_e_series.to_units("degR").units == {
+            "Series 1 degC": unit_registry.degR,
+            "Series 2 degK": unit_registry.degR
+        }
 
     def test_units_value(self, edf):
         """test unit conversion."""


### PR DESCRIPTION
For example, if all columns are degrees (degK, degF or degR). Whole edf can be converted to degC, for example:

```python
>>> import energy_pandas as epd
>>> edf = epd .EnergyDataFrame(
>>>         {
>>>             "Series 1": epd.EnergySeries.with_timeindex(range(0, 8760), units="degC"),
>>>             "Series 2": epd.EnergySeries.with_timeindex(range(0, 8760), units="degK"),
>>>             "Series 3": epd.EnergySeries.with_timeindex(range(0, 8760), units="degR"),
>>>         },
>>> )
>>> edf.to_units("degC").units
{'Series 1': <Unit('degree_Celsius')>, 'Series 2': <Unit('degree_Celsius')>, 'Series 3': <Unit('degree_Celsius')>}
```